### PR TITLE
Create translations import command

### DIFF
--- a/config/filament-translations.php
+++ b/config/filament-translations.php
@@ -96,4 +96,12 @@ return [
     */
 
     'language_switcher_render_hook' => 'panels::user-menu.before',
+
+    /*
+    |--------------------------------------------------------------------------
+    |
+    | Add groups that should be excluded in translation import from files to database
+    |
+    */
+    'exclude_groups' => []
 ];

--- a/src/Console/ImportCommand.php
+++ b/src/Console/ImportCommand.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace TomatoPHP\FilamentTranslations\Console;
+
+use Illuminate\Console\Command;
+use TomatoPHP\FilamentTranslations\Services\Manager;
+
+class ImportCommand extends Command
+{
+    /**
+     * The console command name.
+     *
+     * @var string
+     */
+    protected $signature = 'filament-translations:import 
+                                {--R|replace : Force replace values in database}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Import translations from the language files';
+
+    protected Manager $manager;
+
+    public function __construct()
+    {
+        $this->manager = resolve(Manager::class);
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     */
+    public function handle()
+    {
+        $replace = $this->option('replace');
+        $counter = $this->manager->importTranslations($replace);
+        $this->info('Done importing, processed '.$counter.' items!');
+    }
+
+}

--- a/src/FilamentTranslationsServiceProvider.php
+++ b/src/FilamentTranslationsServiceProvider.php
@@ -4,6 +4,7 @@ namespace TomatoPHP\FilamentTranslations;
 
 use Illuminate\Support\ServiceProvider;
 use Filament\Facades\Filament;
+use TomatoPHP\FilamentTranslations\Console\ImportCommand;
 
 class FilamentTranslationsServiceProvider extends ServiceProvider
 {
@@ -42,6 +43,12 @@ class FilamentTranslationsServiceProvider extends ServiceProvider
 
         //Register Routes
         $this->loadRoutesFrom(__DIR__.'/../routes/web.php');
+
+        $this->app->singleton('command.filament-translations.import', function ($app) {
+            return new ImportCommand();
+        });
+        $this->commands('command.filament-translations.import');
+
     }
 
     public function boot(): void

--- a/src/Services/Manager.php
+++ b/src/Services/Manager.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace TomatoPHP\FilamentTranslations\Services;
+
+use Illuminate\Filesystem\Filesystem;
+use Illuminate\Support\Arr;
+use TomatoPHP\FilamentTranslations\Models\Translation;
+
+class Manager
+{
+    /** @var \Illuminate\Filesystem\Filesystem */
+    protected $files;
+
+    protected $locales;
+
+    public function __construct(Filesystem $files)
+    {
+        $this->files = $files;
+        $this->locales = [];
+    }
+
+    public function importTranslations($replace = false, $base = null, $import_group = false)
+    {
+        $counter = 0;
+        //allows for vendor lang files to be properly recorded through recursion.
+        $vendor = true;
+        if ($base === null) {
+            $base = lang_path();
+            $vendor = false;
+        }
+
+        foreach ($this->files->directories($base) as $langPath) {
+            $locale = basename($langPath);
+            //import langfiles for each vendor
+            if ($locale === 'vendor') {
+                foreach ($this->files->directories($langPath) as $vendor) {
+                    $counter += $this->importTranslations($replace, $vendor);
+                }
+
+                continue;
+            }
+            $vendorName = $this->files->name($this->files->dirname($langPath));
+
+            foreach ($this->files->allfiles($langPath) as $file) {
+                $info = pathinfo($file);
+                $group = $info['filename'];
+                if ($import_group) {
+                    if ($import_group !== $group) {
+                        continue;
+                    }
+                }
+
+                if (in_array($group, config('filament-translations.exclude_groups'))) {
+                    continue;
+                }
+                $subLangPath = str_replace($langPath.DIRECTORY_SEPARATOR, '', $info['dirname']);
+                $subLangPath = str_replace(DIRECTORY_SEPARATOR, '/', $subLangPath);
+                $langPath = str_replace(DIRECTORY_SEPARATOR, '/', $langPath);
+
+                if ($subLangPath != $langPath) {
+                    $group = $subLangPath.'/'.$group;
+                }
+
+                if (! $vendor) {
+                    $translations = \Lang::getLoader()->load($locale, $group);
+                } else {
+                    $translations = include $file;
+                    $group = 'vendor/'.$vendorName.'/'.$group;
+                }
+
+                if ($translations && is_array($translations)) {
+                    foreach (Arr::dot($translations) as $key => $value) {
+                        $importedTranslation = $this->importTranslation($key, $value, $locale, $group, $replace);
+                        $counter += $importedTranslation ? 1 : 0;
+                    }
+                }
+            }
+        }
+
+        return $counter;
+    }
+
+    public function importTranslation($key, $value, $locale, $group, $replace = false)
+    {
+
+        // process only string values
+        if (is_array($value)) {
+            return false;
+        }
+        $value = (string) $value;
+        $translation = Translation::firstOrNew([
+            'group'  => $group,
+            'key'    => $key,
+        ]);
+
+        $text = $translation->text;
+
+        if(empty($text[$locale])) {
+            $text[$locale] = $value;
+            $replace = true;
+        }
+
+        // Check if the database is different then the files
+        if ($text[$locale] !== $value) {
+            $text[$locale] = $value;
+            $replace = true;
+        }
+
+        if ($replace) {
+            $translation->text = $text;
+        }
+
+        $translation->save();
+
+        return true;
+    }
+}


### PR DESCRIPTION
Create artisan command for translation import from `lang/` files to database. Import command is based on [barryvdh/laravel-translation-manager](https://github.com/barryvdh/laravel-translation-manager) package.

To import translations in to database simply run following command:
```bash
php artisan filament-translations:import
```

Additionally, you can include `-R` or `--replace` option to overwrite already existing values in database.