### PR TITLE
Correctly register import command

### DIFF
--- a/src/FilamentTranslationsServiceProvider.php
+++ b/src/FilamentTranslationsServiceProvider.php
@@ -44,10 +44,9 @@ class FilamentTranslationsServiceProvider extends ServiceProvider
         //Register Routes
         $this->loadRoutesFrom(__DIR__.'/../routes/web.php');
 
-        $this->app->singleton('command.filament-translations.import', function ($app) {
-            return new ImportCommand();
-        });
-        $this->commands('command.filament-translations.import');
+        $this->commands([
+           ImportCommand::class
+        ]);
 
     }
 


### PR DESCRIPTION
Translations import command isn't correctly registered during composer install.