### PR TITLE
FEAT: Adds possibility to create own Excel imports ands exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,30 @@ You can create your own command to import the translations, add your custom impo
 
 This command will automatically run when you click on the "Scan For New Languages" button in the UI.
 
+### Custom Excel Import
+
+You can create your own Excel import to import the translations, add your custom import class to the config file like this:
+
+```php
+'path_to_custom_excel_import' => CustomTranslationImport::class,
+```
+
+The import class is based on the Laravel Excel package.
+You can check the documentation [here](https://docs.laravel-excel.com/3.1/imports/).
+This import will automatically run when you click on the "Import" button in the UI.
+
+### Custom Excel Export
+
+You can create your own Excel export to export the translations in your own format, add your custom export class to the config file like this:
+
+```php
+'path_to_custom_excel_export' => CustomTranslationExport::class,
+```
+
+The export class is based on the Laravel Excel package.
+You can check the documentation [here](https://docs.laravel-excel.com/3.1/imports/).
+This import will automatically run when you click on the "Export" button in the UI.
+
 ### Show or hide buttons in the UI
 
 You can show or hide the buttons in the UI by changing the config file. By default, all buttons are shown.

--- a/config/filament-translations.php
+++ b/config/filament-translations.php
@@ -137,4 +137,20 @@ return [
     'scan_enabled' => true,
     'export_enabled' => true,
     'import_enabled' => true,
+
+    /*
+     |--------------------------------------------------------------------------
+     |
+     | Custom Excel export.
+     |
+     */
+    'path_to_custom_excel_export' => null,
+
+    /*
+     |--------------------------------------------------------------------------
+     |
+     | Custom Excel import.
+     |
+     */
+    'path_to_custom_excel_import' => null,
 ];

--- a/src/Exports/CustomTranslationExport.php
+++ b/src/Exports/CustomTranslationExport.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace TomatoPHP\FilamentTranslations\Exports;
+
+use Illuminate\Support\Collection;
+use Maatwebsite\Excel\Concerns\FromCollection;
+use Maatwebsite\Excel\Concerns\WithHeadings;
+use Spatie\TranslationLoader\LanguageLine;
+use Maatwebsite\Excel\Concerns\WithMapping;
+
+class CustomTranslationExport implements FromCollection, WithMapping, WithHeadings
+{
+    public function collection(): Collection
+    {
+        return LanguageLine::all();
+    }
+
+    public function map($row): array
+    {
+        $exportArray = [
+            $row->id,
+            $row->group,
+            $row->key,
+        ];
+
+        $locales = config('filament-translations.locals');
+        foreach ($locales as $key=>$value){
+            $exportArray[] = $row->text[$key] ?? null;
+        }
+
+        return $exportArray;
+    }
+
+    public function headings(): array
+    {
+        $headers = [
+            "id",
+            "group",
+            "key",
+        ];
+
+        $locales = config('filament-translations.locals');
+        foreach ($locales as $key => $value){
+            $headers[] = $key;
+        }
+
+        return $headers;
+    }
+}

--- a/src/Imports/CustomTranslationImport.php
+++ b/src/Imports/CustomTranslationImport.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace TomatoPHP\FilamentTranslations\Imports;
+
+use Illuminate\Support\Collection;
+use Maatwebsite\Excel\Concerns\SkipsOnFailure;
+use Maatwebsite\Excel\Concerns\ToCollection;
+use Maatwebsite\Excel\Concerns\WithHeadingRow;
+use Maatwebsite\Excel\Validators\Failure;
+use Spatie\TranslationLoader\LanguageLine;
+
+class CustomTranslationImport implements ToCollection, WithHeadingRow, SkipsOnFailure
+{
+    public function collection(Collection $collection): void
+    {
+        $locales = config('filament-translations.locals');
+
+        foreach ($collection as $languageLine) {
+            $translation = LanguageLine::firstOrNew(['id' => $languageLine['id']]);
+
+            $mergeTranslation = [];
+            foreach ($locales as $langKey => $lang) {
+                $mergeTranslation[$langKey] = $languageLine[$langKey];
+            }
+            $translation->text = $mergeTranslation;
+            $translation->save();
+        }
+    }
+
+    /**
+     * @param Failure[] $failures
+     */
+    public function onFailure(Failure ...$failures)
+    {
+        // Ignore errors and continue importing
+    }
+}

--- a/src/Resources/TranslationResource.php
+++ b/src/Resources/TranslationResource.php
@@ -17,6 +17,7 @@ use Illuminate\Database\Eloquent\Builder;
 use Spatie\TranslationLoader\LanguageLine;
 use TomatoPHP\FilamentTranslations\Models\Translation;
 use TomatoPHP\FilamentTranslations\Resources\TranslationResource\Pages;
+use TomatoPHP\FilamentTranslations\Services\ExcelImportExportService;
 
 class TranslationResource extends Resource
 {
@@ -108,9 +109,7 @@ class TranslationResource extends Resource
                 ])
                 ->icon('heroicon-o-document-arrow-up')
                 ->color('success')
-                ->action(function (array $data): void {
-                    $this->import($data);
-                });
+                ->action(fn(array $data) => ExcelImportExportService::import($data['file']));
         }
 
         if (config('filament-translations.export_enabled')) {
@@ -118,7 +117,7 @@ class TranslationResource extends Resource
                 ->label(trans('filament-translations::translation.export'))
                 ->icon('heroicon-o-document-arrow-down')
                 ->color('danger')
-                ->action('export');
+                ->action(fn() => ExcelImportExportService::export());
         }
         $table
             ->headerActions($actions)

--- a/src/Resources/TranslationResource/Pages/ListTranslations.php
+++ b/src/Resources/TranslationResource/Pages/ListTranslations.php
@@ -38,22 +38,6 @@ class ListTranslations extends ListRecords
         ];
     }
 
-    public function export()
-    {
-        return Excel::download(new TranslationsExport(), date('d-m-Y-H-i-s') .'-translations.xlsx');
-    }
-
-    public function import(array $data)
-    {
-        $file = $data['file'];
-        Excel::import(new TranslationsImport, $file);
-
-        Notification::make()
-            ->title(trans('filament-translations::translation.uploaded'))
-            ->success()
-            ->send();
-    }
-
     /**
      * @return void
      */

--- a/src/Resources/TranslationResource/Pages/ManageTranslations.php
+++ b/src/Resources/TranslationResource/Pages/ManageTranslations.php
@@ -88,22 +88,6 @@ class ManageTranslations extends ManageRecords
         return $actions;
     }
 
-    public function export()
-    {
-        return Excel::download(new TranslationsExport(), date('d-m-Y-H-i-s') . '-translations.xlsx');
-    }
-
-    public function import(array $data)
-    {
-        $file = $data['file'];
-        Excel::import(new TranslationsImport, $file);
-
-        Notification::make()
-            ->title(trans('filament-translations::translation.uploaded'))
-            ->success()
-            ->send();
-    }
-
     public function scan(): void
     {
         if (config('filament-translations.use_queue_on_scan')) {

--- a/src/Services/ExcelImportExportService.php
+++ b/src/Services/ExcelImportExportService.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace TomatoPHP\FilamentTranslations\Services;
+
+use Filament\Notifications\Notification;
+use Illuminate\Http\UploadedFile;
+use Maatwebsite\Excel\Facades\Excel;
+use Symfony\Component\HttpFoundation\BinaryFileResponse;
+use TomatoPHP\FilamentTranslations\Exports\TranslationsExport;
+use TomatoPHP\FilamentTranslations\Imports\TranslationsImport;
+
+class ExcelImportExportService
+{
+    public static function export(): BinaryFileResponse
+    {
+        $exportClass = config('filament-translations.path_to_custom_excel_export')
+            ?? TranslationsExport::class;
+
+        $fileName = date('Y-m-d-H-i-s') . '-translations.xlsx';
+
+        return Excel::download(new $exportClass(), $fileName);
+    }
+
+    public static function import(UploadedFile|string $file): void
+    {
+        $importClass = config('filament-translations.path_to_custom_excel_import')
+            ?? TranslationsImport::class;
+
+        Excel::import(new $importClass(), $file);
+
+        self::sendSuccessNotification();
+    }
+
+    private static function sendSuccessNotification(): void
+    {
+        Notification::make()
+            ->title(trans('filament-translations::translation.uploaded'))
+            ->success()
+            ->send();
+    }
+}


### PR DESCRIPTION
Hey Fady,

I needed the possibility to customize the Excel imports and exports for a project. That's why I removed the export and import functions from the individual pages and made an ExcelImportExportService, which the resource now uses. The import and/or export class can be changed via the config. I have put my two classes as CustomTranslation in the appropriate folder, in case someone else wants to have them, or you want to use them as default