### PR TITLE
[Feature] Don't translate non-English translations to English when no translation is found

### DIFF
--- a/src/Services/SaveScan.php
+++ b/src/Services/SaveScan.php
@@ -59,7 +59,7 @@ class SaveScan
      * @param $group
      * @param $key
      */
-    protected function createOrUpdate($namespace, $group, $key, $mainKey=null): void
+    protected function createOrUpdate($namespace, $group, $key, $mainKey = null): void
     {
         /** @var Translation $translation */
         $translation = Translation::withTrashed()
@@ -78,7 +78,7 @@ class SaveScan
             $locals = config('filament-translations.locals');
             $text = [];
             foreach ($locals as $locale => $lang) {
-                $text[$locale] = Lang::get($mainKey,[],$locale);
+                $text[$locale] = $locale === 'en' ? Lang::get($mainKey, [], $locale) : '';
             }
             $translation = Translation::make([
                 'namespace' => $namespace,


### PR DESCRIPTION
By default, the non-English translations strings were translated into English. Preferably I don't want that because I want to see which translation strings haven't been translated yet. I made a change which accomplish this. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Adjusted translation handling to ensure that only the English locale retrieves translations, preventing potential issues for other locales.
- **Style**
	- Improved code readability by adding spaces around the equals sign in the method declaration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->