### PR TITLE
Use config-defined resource class in resource pages

### DIFF
--- a/src/FilamentTranslationsPlugin.php
+++ b/src/FilamentTranslationsPlugin.php
@@ -8,6 +8,10 @@ use Illuminate\View\View;
 use Kenepa\TranslationManager\Http\Middleware\SetLanguage;
 use Nwidart\Modules\Module;
 use TomatoPHP\FilamentTranslations\Http\Middleware\LanguageMiddleware;
+use TomatoPHP\FilamentTranslations\Resources\TranslationResource\Pages\CreateTranslation;
+use TomatoPHP\FilamentTranslations\Resources\TranslationResource\Pages\EditTranslation;
+use TomatoPHP\FilamentTranslations\Resources\TranslationResource\Pages\ListTranslations;
+use TomatoPHP\FilamentTranslations\Resources\TranslationResource\Pages\ManageTranslations;
 
 
 class FilamentTranslationsPlugin implements Plugin
@@ -26,18 +30,21 @@ class FilamentTranslationsPlugin implements Plugin
 
     public function register(Panel $panel): void
     {
-        if(class_exists(Module::class) && \Nwidart\Modules\Facades\Module::find('FilamentTranslations')?->isEnabled()){
+        if (class_exists(Module::class) && \Nwidart\Modules\Facades\Module::find('FilamentTranslations')?->isEnabled()) {
             $this->isActive = true;
-        }
-        else {
+        } else {
             $this->isActive = true;
         }
 
+        $resourceClass = config('filament-translations.translation_resource');
+
+        CreateTranslation::setResourceClass($resourceClass);
+        EditTranslation::setResourceClass($resourceClass);
+        ListTranslations::setResourceClass($resourceClass);
+        ManageTranslations::setResourceClass($resourceClass);
+
         if($this->isActive) {
-            $panel
-                ->resources([
-                    config('filament-translations.translation_resource'),
-                ]);
+            $panel->resources([$resourceClass]);
         }
     }
 

--- a/src/Resources/TranslationResource/Pages/CreateTranslation.php
+++ b/src/Resources/TranslationResource/Pages/CreateTranslation.php
@@ -7,7 +7,12 @@ use Filament\Resources\Pages\CreateRecord;
 
 class CreateTranslation extends CreateRecord
 {
-    protected static string $resource = TranslationResource::class;
+    protected static string $resource;
+
+    public static function setResourceClass(string $resourceClass): void
+    {
+        static::$resource = $resourceClass;
+    }
 
     public function getTitle(): string
     {

--- a/src/Resources/TranslationResource/Pages/EditTranslation.php
+++ b/src/Resources/TranslationResource/Pages/EditTranslation.php
@@ -7,7 +7,12 @@ use Filament\Resources\Pages\EditRecord;
 
 class EditTranslation extends EditRecord
 {
-    protected static string $resource = TranslationResource::class;
+    protected static string $resource;
+
+    public static function setResourceClass(string $resourceClass): void
+    {
+        static::$resource = $resourceClass;
+    }
 
     public function getTitle(): string
     {

--- a/src/Resources/TranslationResource/Pages/ListTranslations.php
+++ b/src/Resources/TranslationResource/Pages/ListTranslations.php
@@ -16,8 +16,12 @@ use function Laravel\Prompts\spin;
 class ListTranslations extends ListRecords
 {
 
-    protected static string $resource = TranslationResource::class;
+    protected static string $resource;
 
+    public static function setResourceClass(string $resourceClass): void
+    {
+        static::$resource = $resourceClass;
+    }
 
     public function getTitle(): string
     {

--- a/src/Resources/TranslationResource/Pages/ManageTranslations.php
+++ b/src/Resources/TranslationResource/Pages/ManageTranslations.php
@@ -26,8 +26,13 @@ use TomatoPHP\FilamentTranslations\Resources\TranslationResource;
 
 class ManageTranslations extends ManageRecords
 {
-    protected static string $resource = TranslationResource::class;
+    protected static string $resource;
 
+    public static function setResourceClass(string $resourceClass): void
+    {
+        static::$resource = $resourceClass;
+    }
+    
     public function getTitle(): string
     {
         return trans('filament-translations::translation.title.home');


### PR DESCRIPTION
This update ensures that resource pages use the resource class defined in the filament-translations.translation_resource config, instead of the hardcoded original resource class. Previously, even after updating the config, the admin panel continued using the original resource due to the static $resource property in the page classes.

With this change, the $resource property in the page classes is dynamically set during the plugin's register method, allowing custom resource classes to be fully utilized as intended.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced new translation management pages: Create, Edit, List, and Manage Translations.
	- Added dynamic resource class assignment for improved flexibility in translation management.
	- Enhanced action management in the Manage Translations page, allowing configuration-based actions for scanning translations.

- **Bug Fixes**
	- Improved clarity in the scanning process with updated conditional logic based on configuration settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->