### PR TITLE
Import translations only from php files

### DIFF
--- a/src/Services/Scan.php
+++ b/src/Services/Scan.php
@@ -109,7 +109,10 @@ class Scan
         // FIXME maybe we can count how many times one translation is used and eventually display it to the user
 
         /** @var SplFileInfo $file */
-        foreach ($this->disk->allFiles($this->scannedPaths->toArray()) as $file) {
+        foreach (array_filter(
+            $this->disk->allFiles($this->scannedPaths->toArray()),
+            static fn($fileInfo) => $fileInfo->getExtension() === 'php'
+        ) as $file) {
             $dir = dirname($file);
             if (Str::startsWith($dir, $excludedPaths)) {
                 continue;


### PR DESCRIPTION
This avoids to load translations that are in .md files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved file scanning to include only files with the `.php` extension, reducing unnecessary processing of non-PHP files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->